### PR TITLE
respect `media` folder name change

### DIFF
--- a/snippets/cookie-modal.php
+++ b/snippets/cookie-modal.php
@@ -5,7 +5,7 @@ $features = isset($features) ? $features : [];
 $features = array_merge(option('michnhokn.cookie-banner.features'), $features);
 ?>
 <?php if ($assets): ?>
-    <?= css('media/plugins/michnhokn/cookie-banner/cookie-modal.css') ?>
+    <?= css($kirby->url('media') . '/plugins/michnhokn/cookie-banner/cookie-modal.css') ?>
 <?php endif; ?>
 <div class="cookie-modal cookie-modal--hidden" id="cookie-modal"
      data-show-on-first="<?= $showOnFirst ? 'true' : 'false' ?>">
@@ -44,6 +44,6 @@ $features = array_merge(option('michnhokn.cookie-banner.features'), $features);
     </div>
 </div>
 <?php if ($assets): ?>
-    <?= js('media/plugins/michnhokn/cookie-banner/cookie-modal.js', ['defer' => true]) ?>
+    <?= js($kirby->url('media') . '/plugins/michnhokn/cookie-banner/cookie-modal.js', ['defer' => true]) ?>
 <?php endif; ?>
 


### PR DESCRIPTION
this fix will ensure that plugin assets are being loaded from the correct place, if the root/URL of the media folder is changed to something else globally via Kirby's init settings